### PR TITLE
Convert project to TypeScript

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,5 +13,8 @@ RUN npm install
 # Copy the rest of the application code
 COPY . .
 
+# Build the TypeScript code
+RUN npm run build
+
 # Specify the command to run the script
-CMD ["node", "lookup-cli.js"]
+CMD ["node", "dist/lookup-cli.js"]

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ To run the `lookup-cli` script, follow these steps:
 
 2. Run the script with the required parameters:
    ```
-   node lookup-cli.js <name> <output_field>
+   node dist/lookup-cli.js <name> <output_field>
    ```
 
 Replace `<name>` and `<output_field>` with the appropriate values.

--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "name": "lookup-cli",
   "version": "1.0.0",
   "description": "A command-line tool to lookup fields for a given name in a YAML file.",
-  "main": "lookup-cli.js",
+  "main": "dist/lookup-cli.js",
   "scripts": {
-    "start": "node lookup-cli.js"
+    "start": "node dist/lookup-cli.js"
   },
   "keywords": [],
   "author": "",
@@ -12,5 +12,11 @@
   "dependencies": {
     "commander": "^12.1.0",
     "js-yaml": "^4.1.0"
+  },
+  "devDependencies": {
+    "typescript": "^4.3.5",
+    "@types/node": "^14.14.37",
+    "@types/js-yaml": "^4.0.5",
+    "@types/commander": "^2.12.2"
   }
 }

--- a/src/lookup-cli.ts
+++ b/src/lookup-cli.ts
@@ -1,12 +1,19 @@
-const fs = require('fs');
-const yaml = require('js-yaml');
-const { Command } = require('commander');
+import * as fs from 'fs';
+import * as yaml from 'js-yaml';
+import { Command } from 'commander';
 const program = new Command();
 
-function readYAMLFile(filePath) {
+interface YAMLData {
+  name: string;
+  age?: number;
+  occupation?: string;
+  [key: string]: any;
+}
+
+function readYAMLFile(filePath: string): YAMLData[] {
   try {
     const fileContents = fs.readFileSync(filePath, 'utf8');
-    return yaml.load(fileContents);
+    return yaml.load(fileContents) as YAMLData[];
   } catch (e) {
     if (e.code === 'ENOENT') {
       console.error('Error: YAML file not found at the specified location. Please check the file path and try again.');
@@ -19,7 +26,7 @@ function readYAMLFile(filePath) {
 
 program
   .arguments('<name> <output_field>')
-  .action((name, outputField) => {
+  .action((name: string, outputField: string) => {
     const data = readYAMLFile('data.yaml');
     const nameLower = name.toLowerCase();
     const outputFieldLower = outputField.toLowerCase();

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1,0 +1,26 @@
+import { execSync } from 'child_process';
+import * as path from 'path';
+
+describe('Command-line interface', () => {
+  const cliPath = path.join(__dirname, '../dist/lookup-cli.js');
+
+  it('should return the correct field value for a given name', () => {
+    const output = execSync(`node ${cliPath} Alice age`).toString();
+    expect(output.trim()).toBe('18');
+  });
+
+  it('should return "Name not found" if the name is not in the YAML file', () => {
+    const output = execSync(`node ${cliPath} Eve age`).toString();
+    expect(output.trim()).toBe('Name not found');
+  });
+
+  it('should return an error message if the field is not found for the given name', () => {
+    const output = execSync(`node ${cliPath} Charlie occupation`).toString();
+    expect(output.trim()).toBe("Field 'occupation' not found for 'Charlie'. Available fields: 'name', 'age'.");
+  });
+
+  it('should display the help message if no arguments are provided', () => {
+    const output = execSync(`node ${cliPath}`).toString();
+    expect(output).toContain('Usage: lookup-cli <name> <output_field>');
+  });
+});

--- a/tests/readYAMLFile.test.ts
+++ b/tests/readYAMLFile.test.ts
@@ -1,0 +1,68 @@
+import { readYAMLFile } from '../src/lookup-cli';
+import * as fs from 'fs';
+import * as yaml from 'js-yaml';
+
+jest.mock('fs');
+jest.mock('js-yaml');
+
+describe('readYAMLFile', () => {
+  it('should read and parse a valid YAML file', () => {
+    const filePath = 'data.yaml';
+    const fileContents = 'name: Alice\nage: 30\noccupation: Engineer';
+    const parsedData = { name: 'Alice', age: 30, occupation: 'Engineer' };
+
+    (fs.readFileSync as jest.Mock).mockReturnValue(fileContents);
+    (yaml.load as jest.Mock).mockReturnValue(parsedData);
+
+    const result = readYAMLFile(filePath);
+
+    expect(fs.readFileSync).toHaveBeenCalledWith(filePath, 'utf8');
+    expect(yaml.load).toHaveBeenCalledWith(fileContents);
+    expect(result).toEqual(parsedData);
+  });
+
+  it('should handle file not found error', () => {
+    const filePath = 'data.yaml';
+    const error = new Error('File not found');
+    (error as any).code = 'ENOENT';
+
+    (fs.readFileSync as jest.Mock).mockImplementation(() => {
+      throw error;
+    });
+
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const processExitSpy = jest.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit called');
+    });
+
+    expect(() => readYAMLFile(filePath)).toThrow('process.exit called');
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Error: YAML file not found at the specified location. Please check the file path and try again.');
+    expect(processExitSpy).toHaveBeenCalledWith(1);
+
+    consoleErrorSpy.mockRestore();
+    processExitSpy.mockRestore();
+  });
+
+  it('should handle YAML parsing error', () => {
+    const filePath = 'data.yaml';
+    const fileContents = 'invalid: yaml: content';
+    const error = new Error('YAML parsing error');
+
+    (fs.readFileSync as jest.Mock).mockReturnValue(fileContents);
+    (yaml.load as jest.Mock).mockImplementation(() => {
+      throw error;
+    });
+
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const processExitSpy = jest.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit called');
+    });
+
+    expect(() => readYAMLFile(filePath)).toThrow('process.exit called');
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Error: YAML file is not properly formatted. Please check the file content and try again.');
+    expect(processExitSpy).toHaveBeenCalledWith(1);
+
+    consoleErrorSpy.mockRestore();
+    processExitSpy.mockRestore();
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES6",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "**/*.spec.ts"]
+}


### PR DESCRIPTION
Convert the project from JavaScript to TypeScript.

* **Rename and Update Main Script**: Rename `lookup-cli.js` to `src/lookup-cli.ts` and update the code to use TypeScript syntax and type annotations. Define an interface for the YAML data.
* **Add TypeScript Configuration**: Add `tsconfig.json` to configure TypeScript settings.
* **Update Dockerfile**: Modify the `CMD` instruction to use `dist/lookup-cli.js` and add a step to build the TypeScript code.
* **Update package.json**: Change the `main` field to `"dist/lookup-cli.js"` and update the `start` script to `"node dist/lookup-cli.js"`. Add TypeScript and type definitions as dev dependencies.
* **Update README.md**: Reflect the changes in file names and instructions for running the TypeScript file.
* **Add Unit Tests**: Add `tests/readYAMLFile.test.ts` and `tests/cli.test.ts` to test the `readYAMLFile` function and the command-line interface using Jest.
